### PR TITLE
Module throws error when activated in ContentBox

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -87,7 +87,7 @@ component {
 		// Install the ckeditor plugin
 		var ckeditorPluginsPath = controller.getSetting("modules")["contentbox-admin"].path & "/includes/ckeditor/plugins/cbGooglePrettify";
 		var fileUtils = controller.getWireBox().getInstance("fileUtils@google-prettify");
-		var pluginPath = controller.getSetting("modules")["google-prettify"].path & "/includes/cbGooglePrettify";
+		var pluginPath = controller.getSetting("modules")["googlePrettify"].path & "/includes/cbGooglePrettify";
 		fileUtils.directoryCopy(source=pluginPath, destination=ckeditorPluginsPath);
 	}
 

--- a/interceptors/Prettify.cfc
+++ b/interceptors/Prettify.cfc
@@ -19,7 +19,7 @@ component extends="coldbox.system.Interceptor"{
 	* cbui_beforeHeadEnd
 	*/
 	function cbui_beforeHeadEnd(event, interceptData){
-		var modRoot = event.getModuleRoot("google-prettify");
+		var modRoot = event.getModuleRoot("googlePrettify");
 		// add link and script
 		appendToBuffer('<link href="#modRoot#/includes/google-code-prettify/prettify.css" type="text/css" rel="stylesheet" />');
 		appendToBuffer('<script type="text/javascript" src="#modRoot#/includes/google-code-prettify/prettify.js"></script>');


### PR DESCRIPTION
The module is registered as googlePrettify but in the interceptor and the ModuleConfig is referenced as google-prettify, hence throwing an
error when activating the module and running the cbui_beforeHeadEnd
interceptor.
